### PR TITLE
feat: ajoute la fonctionnalité d'enregistrement d'un utilisateur en bd

### DIFF
--- a/backend-implicaction/pom.xml
+++ b/backend-implicaction/pom.xml
@@ -61,6 +61,15 @@
 			<artifactId>spring-security-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>jakarta.validation</groupId>
+			<artifactId>jakarta.validation-api</artifactId>
+			<version>2.0.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-thymeleaf</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/config/SecurityConfig.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/config/SecurityConfig.java
@@ -1,0 +1,28 @@
+package com.dynonuggets.refonteimplicaction.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Override
+    protected void configure(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.csrf().disable()
+                .authorizeRequests()
+                // désactive l'authentification pour les requêtes dont l'url commence par /api/auth/
+                .antMatchers("/api/auth/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/AuthController.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.dynonuggets.refonteimplicaction.controller;
+
+import com.dynonuggets.refonteimplicaction.dto.ReqisterRequestDto;
+import com.dynonuggets.refonteimplicaction.exception.ImplicitActionException;
+import com.dynonuggets.refonteimplicaction.service.AuthService;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequestMapping("/api/auth")
+@AllArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<String> signup(@RequestBody ReqisterRequestDto reqisterRequest) throws ImplicitActionException {
+        authService.signup(reqisterRequest);
+        return new ResponseEntity<>("User registration successful", OK);
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/AuthController.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/controller/AuthController.java
@@ -21,7 +21,7 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody ReqisterRequestDto reqisterRequest) throws ImplicitActionException {
-        authService.signup(reqisterRequest);
+        authService.signupAndSendConfirmation(reqisterRequest);
         return new ResponseEntity<>("User registration successful", OK);
     }
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/NotificationEmailDto.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/NotificationEmailDto.java
@@ -1,0 +1,14 @@
+package com.dynonuggets.refonteimplicaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+@Builder
+public class NotificationEmailDto {
+    private String subject;
+    private String recipient;
+    private String body;
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/ReqisterRequestDto.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/dto/ReqisterRequestDto.java
@@ -1,0 +1,16 @@
+package com.dynonuggets.refonteimplicaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ReqisterRequestDto {
+    private String login;
+    private String email;
+    private String password;
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/exception/ImplicitActionException.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/exception/ImplicitActionException.java
@@ -1,0 +1,7 @@
+package com.dynonuggets.refonteimplicaction.exception;
+
+public class ImplicitActionException extends Throwable {
+    public ImplicitActionException(String message) {
+        super(message);
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/model/SignUp.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/model/SignUp.java
@@ -1,0 +1,37 @@
+package com.dynonuggets.refonteimplicaction.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+import static javax.persistence.GenerationType.SEQUENCE;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Builder
+@Table(name = "wp_signups")
+public class SignUp {
+    @Id
+    @GeneratedValue(strategy = SEQUENCE)
+    @Column(name = "signup_id")
+    private Long signupId;
+    private String domain;
+    private String path;
+    private String title;
+    @Column(name = "user_login")
+    private String userLogin;
+    @Column(name = "user_email")
+    private String userEmail;
+    private Instant registered;
+    private Instant activated;
+    private Boolean active;
+    @Column(name = "activation_key")
+    private String activationKey;
+    private String meta;
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/model/User.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/model/User.java
@@ -1,0 +1,48 @@
+package com.dynonuggets.refonteimplicaction.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import java.time.Instant;
+
+import static javax.persistence.GenerationType.SEQUENCE;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Entity
+@Builder
+@Table(name = "wp_users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = SEQUENCE)
+    private Long id;
+    @Column(name = "user_login", unique = true)
+    @NotBlank(message = "login is required")
+    private String login;
+    @Column(name = "user_pass")
+    @NotBlank(message = "password is required")
+    private String password;
+    @Column(name = "user_nicename")
+    private String nicename;
+    @Column(name = "user_email", unique = true)
+    @NotEmpty(message = "Email is required")
+    @Email
+    private String email;
+    @Column(name = "user_url")
+    private String url;
+    @Column(name = "user_registered")
+    private Instant registered;
+    @Column(name = "user_activation_key")
+    private String activationKey;
+    @Column(name = "user_status")
+    private Integer status;
+    @Column(name = "display_name")
+    private String dispayName;
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/UserRepository.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.dynonuggets.refonteimplicaction.repository;
+
+import com.dynonuggets.refonteimplicaction.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
@@ -13,7 +13,7 @@ import javax.transaction.Transactional;
 import java.time.Instant;
 import java.util.UUID;
 
-import static com.dynonuggets.refonteimplicaction.util.Constants.ACTIVATION_EMAIL;
+import static com.dynonuggets.refonteimplicaction.util.Constants.ACTIVATION_ENDPOINT;
 
 @Service
 @AllArgsConstructor
@@ -23,8 +23,14 @@ public class AuthService {
     private final UserRepository userRepository;
     private final MailService mailService;
 
+    /**
+     * Enregistre un utilisateur en base de données et lui envoie un mail d'activation
+     * @param reqisterRequest données d'identification de l'utilisateur
+     * @throws ImplicitActionException si l'envoi du mail échoue
+     * TODO: notifier lors de l'existance d'un utilisateur ayant le même mail ou login
+     */
     @Transactional
-    public void signup(ReqisterRequestDto reqisterRequest) throws ImplicitActionException {
+    public void signupAndSendConfirmation(ReqisterRequestDto reqisterRequest) throws ImplicitActionException {
         final String activationKey = generateActivationKey();
 
         User user = User.builder()
@@ -40,7 +46,7 @@ public class AuthService {
                 .subject("Please activate your account")
                 .recipient(user.getEmail())
                 .body("Thank you for signing up to Spring Reddit, please click on the below url to activate your account : "
-                        + ACTIVATION_EMAIL + "/" + activationKey)
+                        + ACTIVATION_ENDPOINT + "/" + activationKey)
                 .build();
         mailService.sendMail(notificationEmail);
     }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
@@ -1,0 +1,51 @@
+package com.dynonuggets.refonteimplicaction.service;
+
+import com.dynonuggets.refonteimplicaction.dto.NotificationEmailDto;
+import com.dynonuggets.refonteimplicaction.dto.ReqisterRequestDto;
+import com.dynonuggets.refonteimplicaction.exception.ImplicitActionException;
+import com.dynonuggets.refonteimplicaction.model.User;
+import com.dynonuggets.refonteimplicaction.repository.UserRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.dynonuggets.refonteimplicaction.util.Constants.ACTIVATION_EMAIL;
+
+@Service
+@AllArgsConstructor
+public class AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final MailService mailService;
+
+    @Transactional
+    public void signup(ReqisterRequestDto reqisterRequest) throws ImplicitActionException {
+        final String activationKey = generateActivationKey();
+
+        User user = User.builder()
+                .login(reqisterRequest.getLogin())
+                .email(reqisterRequest.getEmail())
+                .password(passwordEncoder.encode(reqisterRequest.getPassword()))
+                .registered(Instant.now())
+                .activationKey(activationKey)
+                .build();
+        userRepository.save(user);
+
+        NotificationEmailDto notificationEmail = NotificationEmailDto.builder()
+                .subject("Please activate your account")
+                .recipient(user.getEmail())
+                .body("Thank you for signing up to Spring Reddit, please click on the below url to activate your account : "
+                        + ACTIVATION_EMAIL + "/" + activationKey)
+                .build();
+        mailService.sendMail(notificationEmail);
+    }
+
+    private String generateActivationKey() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/MailContentBuilder.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/MailContentBuilder.java
@@ -1,0 +1,22 @@
+package com.dynonuggets.refonteimplicaction.service;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@AllArgsConstructor
+class MailContentBuilder {
+
+    private static final String MAIL_TEMPLATE_FILE = "mail-template";
+    private final static String MESSAGE_VAR_NAME = "message";
+
+    private final TemplateEngine templateEngine;
+
+    String build(String message) {
+        Context context = new Context();
+        context.setVariable(MESSAGE_VAR_NAME, message);
+        return templateEngine.process(MAIL_TEMPLATE_FILE, context);
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/MailService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/MailService.java
@@ -1,0 +1,36 @@
+package com.dynonuggets.refonteimplicaction.service;
+
+import com.dynonuggets.refonteimplicaction.dto.NotificationEmailDto;
+import com.dynonuggets.refonteimplicaction.exception.ImplicitActionException;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Service;
+
+@Service
+@AllArgsConstructor
+@Slf4j
+public class MailService {
+
+    private final MailContentBuilder mailContentBuilder;
+    private final JavaMailSender mailSender;
+
+    void sendMail(NotificationEmailDto notificationEmail) throws ImplicitActionException {
+        MimeMessagePreparator messagePreparator = mimeMessage -> {
+            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage);
+            messageHelper.setFrom("implicaction@email.com");
+            messageHelper.setTo(notificationEmail.getRecipient());
+            messageHelper.setSubject(notificationEmail.getSubject());
+            messageHelper.setText(mailContentBuilder.build(notificationEmail.getBody()));
+        };
+        try {
+            mailSender.send(messagePreparator);
+            log.info("Activation email sent!!");
+        } catch (MailException e) {
+            throw new ImplicitActionException("Exception occurred when sending mail to " + notificationEmail.getRecipient());
+        }
+    }
+}

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/util/Constants.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/util/Constants.java
@@ -4,5 +4,5 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class Constants {
-    public static final String ACTIVATION_EMAIL = "http://localhost:8080/api/auth/accountVerification";
+    public static final String ACTIVATION_ENDPOINT = "http://localhost:8080/api/auth/accountVerification";
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/util/Constants.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/util/Constants.java
@@ -1,0 +1,8 @@
+package com.dynonuggets.refonteimplicaction.util;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class Constants {
+    public static final String ACTIVATION_EMAIL = "http://localhost:8080/api/auth/accountVerification";
+}

--- a/backend-implicaction/src/main/resources/application.properties
+++ b/backend-implicaction/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+# db properties
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/implicaction
 spring.datasource.username=root
@@ -6,3 +7,10 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL5InnoDBDialec
 spring.jpa.hibernate.ddl-auto=update
 spring.sql.init.mode=always
 spring.jpa.show-sql=true
+
+# mail properties
+spring.mail.host=smtp.mailtrap.io
+spring.mail.port=2525
+spring.mail.username=5c354372a1d5da
+spring.mail.password=6b3338fa1cc8b9
+spring.mail.protocol=smtp

--- a/backend-implicaction/src/main/resources/templates/mail-template.html
+++ b/backend-implicaction/src/main/resources/templates/mail-template.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>Implicaction</title>
+</head>
+<body>
+<span th:text="${message}"></span>
+</body>
+</html>


### PR DESCRIPTION
 * nécessite l'envoie d'une requête post à l'endpoint /api/auth/signup
 * envoie d'un mail de confirmation
 * ajout de la dépendance jakarta.validation-api pour la validation des champs du model
 * ajout de la dépendance spring-boot-starter-thymeleaf nécessaire à la création du template du mail