### PR TITLE
Ri 74: met en place la capture des erreurs http au niveau du front

### DIFF
--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/handler/GlobalExceptionHandler.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/handler/GlobalExceptionHandler.java
@@ -35,12 +35,12 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     }
 
     @ExceptionHandler(value = BadCredentialsException.class)
-    public ResponseEntity<ExceptionResponse> badCredentialsException(Exception ex) {
+    public ResponseEntity<ExceptionResponse> badCredentialsException() {
         return generateResponse(BAD_CREDENTIAL_MSG, UNAUTHORIZED);
     }
 
     @ExceptionHandler(value = DisabledException.class)
-    public ResponseEntity<ExceptionResponse> disabledException(Exception ex) {
+    public ResponseEntity<ExceptionResponse> disabledException() {
         return generateResponse(USER_DISABLED_MSG, UNAUTHORIZED);
     }
 

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/handler/GlobalExceptionHandler.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/handler/GlobalExceptionHandler.java
@@ -4,7 +4,10 @@ import com.dynonuggets.refonteimplicaction.dto.ExceptionResponse;
 import com.dynonuggets.refonteimplicaction.exception.NotFoundException;
 import com.dynonuggets.refonteimplicaction.exception.UnauthorizedException;
 import com.dynonuggets.refonteimplicaction.exception.UserNotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -18,29 +21,38 @@ import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 @ControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
+    private static final String BAD_CREDENTIAL_MSG = "Nom d'utilisateur ou mot de passe incorrect.";
+    private static final String USER_DISABLED_MSG = "Votre compte n'a pas encore été activé.";
+
     @ExceptionHandler(value = {UnauthorizedException.class, AuthenticationException.class})
     public ResponseEntity<ExceptionResponse> unauthorizedException(Exception ex) {
-        ExceptionResponse response = ExceptionResponse.builder()
-                .errorMessage(ex.getMessage())
-                .errorCode(UNAUTHORIZED.value())
-                .timestamp(LocalDateTime.now())
-                .build();
-
-        return ResponseEntity
-                .status(UNAUTHORIZED)
-                .body(response);
+        return generateResponse(ex.getMessage(), UNAUTHORIZED);
     }
 
     @ExceptionHandler(value = {NotFoundException.class, UserNotFoundException.class})
     public ResponseEntity<ExceptionResponse> userNotFoundException(Exception ex) {
+        return generateResponse(ex.getMessage(), NOT_FOUND);
+    }
+
+    @ExceptionHandler(value = BadCredentialsException.class)
+    public ResponseEntity<ExceptionResponse> badCredentialsException(Exception ex) {
+        return generateResponse(BAD_CREDENTIAL_MSG, UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(value = DisabledException.class)
+    public ResponseEntity<ExceptionResponse> disabledException(Exception ex) {
+        return generateResponse(USER_DISABLED_MSG, UNAUTHORIZED);
+    }
+
+    private ResponseEntity<ExceptionResponse> generateResponse(final String message, final HttpStatus httpStatus) {
         ExceptionResponse response = ExceptionResponse.builder()
-                .errorMessage(ex.getMessage())
-                .errorCode(NOT_FOUND.value())
+                .errorMessage(message)
+                .errorCode(httpStatus.value())
                 .timestamp(LocalDateTime.now())
                 .build();
 
         return ResponseEntity
-                .status(NOT_FOUND)
+                .status(httpStatus)
                 .body(response);
     }
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/UserRepository.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/repository/UserRepository.java
@@ -3,10 +3,13 @@ package com.dynonuggets.refonteimplicaction.repository;
 import com.dynonuggets.refonteimplicaction.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
 
     Optional<User> findByActivationKey(String activationKey);
+
+    List<User> findAllByUsernameOrEmail(String username, String email);
 }

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
@@ -3,6 +3,7 @@ package com.dynonuggets.refonteimplicaction.service;
 import com.dynonuggets.refonteimplicaction.adapter.UserAdapter;
 import com.dynonuggets.refonteimplicaction.dto.*;
 import com.dynonuggets.refonteimplicaction.exception.ImplicactionException;
+import com.dynonuggets.refonteimplicaction.exception.UnauthorizedException;
 import com.dynonuggets.refonteimplicaction.model.JobSeeker;
 import com.dynonuggets.refonteimplicaction.model.Role;
 import com.dynonuggets.refonteimplicaction.model.RoleEnum;
@@ -12,6 +13,7 @@ import com.dynonuggets.refonteimplicaction.repository.RoleRepository;
 import com.dynonuggets.refonteimplicaction.repository.UserRepository;
 import com.dynonuggets.refonteimplicaction.security.JwtProvider;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -30,8 +32,12 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 @Service
+@Slf4j
 @AllArgsConstructor
 public class AuthService {
+
+    private static final String USERNAME_ALREADY_EXISTS_MSG = "Un compte utilisateur existe déjà avec ce nom d'utilisateur.";
+    private static final String EMAIL_ALREADY_EXISTS_MSG = "Un compte utilisateur existe déjà avec cette adresse email.";
 
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
@@ -52,10 +58,22 @@ public class AuthService {
      */
     @Transactional
     public void signup(ReqisterRequestDto reqisterRequest) throws ImplicactionException {
-        // TODO: notifier lors de l'existence d'un utilisateur ayant le même mail ou login
+        validateRequest(reqisterRequest);
         final String activationKey = generateActivationKey();
         final User user = registerUser(reqisterRequest, activationKey);
         mailService.sendUserActivationMail(activationKey, user);
+    }
+
+    /**
+     * Vérifie la validité de la requête de sign-up
+     */
+    private void validateRequest(ReqisterRequestDto reqisterRequest) {
+        userRepository.findAllByUsernameOrEmail(reqisterRequest.getUsername(), reqisterRequest.getEmail())
+                .forEach(user -> {
+                    String message = user.getUsername().equals(reqisterRequest.getUsername()) ?
+                            USERNAME_ALREADY_EXISTS_MSG : EMAIL_ALREADY_EXISTS_MSG;
+                    throw new UnauthorizedException(message);
+                });
     }
 
     /**

--- a/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
+++ b/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/service/AuthService.java
@@ -58,7 +58,7 @@ public class AuthService {
      */
     @Transactional
     public void signup(ReqisterRequestDto reqisterRequest) throws ImplicactionException {
-        validateRequest(reqisterRequest);
+        validateRegisterRequest(reqisterRequest);
         final String activationKey = generateActivationKey();
         final User user = registerUser(reqisterRequest, activationKey);
         mailService.sendUserActivationMail(activationKey, user);
@@ -67,7 +67,7 @@ public class AuthService {
     /**
      * Vérifie la validité de la requête de sign-up
      */
-    private void validateRequest(ReqisterRequestDto reqisterRequest) {
+    private void validateRegisterRequest(ReqisterRequestDto reqisterRequest) {
         userRepository.findAllByUsernameOrEmail(reqisterRequest.getUsername(), reqisterRequest.getEmail())
                 .forEach(user -> {
                     String message = user.getUsername().equals(reqisterRequest.getUsername()) ?

--- a/frontend-implicaction/src/app/auth/auth.module.ts
+++ b/frontend-implicaction/src/app/auth/auth.module.ts
@@ -5,6 +5,7 @@ import {AuthRoutingModule} from './auth-routing.module';
 import {ReactiveFormsModule} from '@angular/forms';
 import {LoginComponent} from './components/login/login.component';
 import {UnauthorizedComponent} from './components/unauthorized/unauthorized.component';
+import {SharedModule} from '../shared/shared.module';
 
 
 @NgModule({
@@ -19,7 +20,8 @@ import {UnauthorizedComponent} from './components/unauthorized/unauthorized.comp
   imports: [
     CommonModule,
     AuthRoutingModule,
-    ReactiveFormsModule
+    ReactiveFormsModule,
+    SharedModule,
   ]
 })
 export class AuthModule {

--- a/frontend-implicaction/src/app/auth/components/login/login.component.html
+++ b/frontend-implicaction/src/app/auth/components/login/login.component.html
@@ -106,15 +106,7 @@
         </form>
 
         <!-- ALERT MESSAGES -->
-        <ng-container *ngIf="showAlert">
-          <div
-            class="alert alert-{{alert.severity}} mt-4"
-            role="alert"
-          >
-            <h4 class="alert-heading">{{alert.title}}</h4>
-            <p>{{alert.body}}</p>
-          </div>
-        </ng-container>
+        <app-alert></app-alert>
       </div>
     </div>
   </div>

--- a/frontend-implicaction/src/app/auth/components/login/login.component.ts
+++ b/frontend-implicaction/src/app/auth/components/login/login.component.ts
@@ -5,6 +5,7 @@ import {LoginRequestPayload} from '../../../shared/models/login-request-payload'
 import {ActivatedRoute, Router} from '@angular/router';
 import {ToasterService} from '../../../core/services/toaster.service';
 import {finalize} from 'rxjs/operators';
+import {AlertService} from '../../../shared/services/alert.service';
 
 @Component({
   selector: 'app-login',
@@ -15,8 +16,6 @@ export class LoginComponent implements OnInit {
 
   loginForm: FormGroup;
   loginRequestPayload: LoginRequestPayload;
-  showAlert: boolean;
-  alert: { title: string, severity: string, body: string };
   isLoading = false;
 
   constructor(
@@ -24,6 +23,7 @@ export class LoginComponent implements OnInit {
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private toaster: ToasterService,
+    private alertService: AlertService
   ) {
     if (this.authService.isLoggedIn()) {
       this.router.navigate(['/']);
@@ -32,17 +32,6 @@ export class LoginComponent implements OnInit {
         username: '',
         password: ''
       };
-
-      this.activatedRoute
-        .queryParams
-        .subscribe(params => {
-          this.showAlert = params.registered && params.registered === 'true';
-          this.alert = {
-            title: 'Félicitation',
-            body: 'Votre inscription a bien été enregistrée. Elle doit maintenant être validée par un administrateur.',
-            severity: 'success'
-          };
-        });
     }
   }
 
@@ -68,20 +57,14 @@ export class LoginComponent implements OnInit {
       .pipe(finalize(() => this.isLoading = false))
       .subscribe(isLoginSuccess => {
         if (isLoginSuccess) {
-          this.showAlert = false;
-          this.redirectAndToastSuccess();
+          this.redirectSuccess();
         } else {
-          this.showAlert = true;
-          this.alert = {
-            title: 'Erreur',
-            body: `Nom d'utilisateur ou mot de passe incorrect.`,
-            severity: 'danger'
-          };
+          this.alertService.error('Erreur', `Nom d'utilisateur ou mot de passe incorrect.`);
         }
       });
   }
 
-  private redirectAndToastSuccess(): void {
+  private redirectSuccess(): void {
     this.activatedRoute
       .queryParams
       .subscribe(

--- a/frontend-implicaction/src/app/auth/components/signup/signup.component.html
+++ b/frontend-implicaction/src/app/auth/components/signup/signup.component.html
@@ -122,13 +122,7 @@
           </div>
         </form>
 
-        <!-- ALERT MESSAGES -->
-        <ng-container *ngIf="isError">
-          <div class="alert alert-danger mt-4" role="alert">
-            <h4 class="alert-heading">Erreur</h4>
-            <p>Une erreur est survenue lors de votre inscription. Veuillez recommencer</p>
-          </div>
-        </ng-container>
+        <app-alert></app-alert>
       </div>
     </div>
   </div>

--- a/frontend-implicaction/src/app/auth/components/signup/signup.component.ts
+++ b/frontend-implicaction/src/app/auth/components/signup/signup.component.ts
@@ -70,8 +70,8 @@ export class SignupComponent implements OnInit {
       .pipe(finalize(() => this.isLoading = false))
       .subscribe(
         () => {
-          this.router.navigate(['/auth/login'], {queryParams: {registered: 'true'}})
-            .then(() => this.alertService.success('Félicitation', 'Votre inscription a bien été enregistrée. Elle doit maintenant être validée par un administrateur.'));
+          this.router.navigate(['/auth/login'])
+            .then(() => this.alertService.success('Félicitations', 'Votre inscription a bien été enregistrée. Elle doit maintenant être validée par un administrateur.'));
         },
         () => this.isError = true
       );

--- a/frontend-implicaction/src/app/auth/components/signup/signup.component.ts
+++ b/frontend-implicaction/src/app/auth/components/signup/signup.component.ts
@@ -6,6 +6,7 @@ import {Router} from '@angular/router';
 import {ToasterService} from '../../../core/services/toaster.service';
 import {RoleEnum} from '../../../shared/enums/role-enum.enum';
 import {finalize} from 'rxjs/operators';
+import {AlertService} from '../../../shared/services/alert.service';
 
 @Component({
   selector: 'app-signup',
@@ -23,6 +24,7 @@ export class SignupComponent implements OnInit {
     private authService: AuthService,
     private toaster: ToasterService,
     private router: Router,
+    private alertService: AlertService
   ) {
     if (this.authService.isLoggedIn()) {
       this.router.navigate(['/']);
@@ -67,7 +69,10 @@ export class SignupComponent implements OnInit {
       .signup(this.signupRequestPayload)
       .pipe(finalize(() => this.isLoading = false))
       .subscribe(
-        () => this.router.navigate(['/auth/login'], {queryParams: {registered: 'true'}}),
+        () => {
+          this.router.navigate(['/auth/login'], {queryParams: {registered: 'true'}})
+            .then(() => this.alertService.success('Félicitation', 'Votre inscription a bien été enregistrée. Elle doit maintenant être validée par un administrateur.'));
+        },
         () => this.isError = true
       );
   }

--- a/frontend-implicaction/src/app/core/core.module.ts
+++ b/frontend-implicaction/src/app/core/core.module.ts
@@ -3,6 +3,7 @@ import {CommonModule} from '@angular/common';
 import {Constants} from '../config/constants';
 import {HTTP_INTERCEPTORS} from '@angular/common/http';
 import {JwtInterceptor} from './interceptors/jwt.interceptor';
+import {HttpErrorInterceptor} from './interceptors/http-error.interceptor';
 
 /**
  * Cette classe abstraite utilisée pour la construction de modules, empêche l'importation du module dans un autre endroit
@@ -26,6 +27,11 @@ export abstract class EnsureImportedOnceModule {
     {
       provide: HTTP_INTERCEPTORS,
       useClass: JwtInterceptor,
+      multi: true
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: HttpErrorInterceptor,
       multi: true
     }
   ]

--- a/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.spec.ts
+++ b/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {HttpErrorInterceptor} from './http-error.interceptor';
+
+describe('HttpErrorInterceptor', () => {
+  beforeEach(() => TestBed.configureTestingModule({
+    providers: [
+      HttpErrorInterceptor
+    ]
+  }));
+
+  it('should be created', () => {
+    const interceptor: HttpErrorInterceptor = TestBed.inject(HttpErrorInterceptor);
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.ts
+++ b/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.ts
@@ -1,0 +1,61 @@
+import {Injectable} from '@angular/core';
+import {HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
+import {Observable, of, throwError} from 'rxjs';
+import {Router} from '@angular/router';
+import {AlertService} from '../../shared/services/alert.service';
+import {catchError, retry} from 'rxjs/operators';
+
+@Injectable()
+export class HttpErrorInterceptor implements HttpInterceptor {
+
+  constructor(private router: Router, private alertService: AlertService) {
+  }
+
+  private static handleServerSideError(error: HttpErrorResponse): boolean {
+    let handled = false;
+
+    switch (error.status) {
+      case 401:
+        handled = true;
+        break;
+      case 403:
+        handled = true;
+        break;
+    }
+
+    return handled;
+  }
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    let handled = false;
+
+    return next.handle(request)
+      .pipe(
+        retry(1),
+        catchError(returnedError => {
+          let errorMessage = null;
+          if (returnedError instanceof HttpErrorResponse) {
+            // FIXME: trouver pourquoi le back renvoie du string au lieu d'une erreur si le username/email est
+            // déjà utilisé lors d'un signup
+            errorMessage = typeof returnedError.error === 'string' ?
+              JSON.parse(returnedError.error).errorMessage : returnedError.error.errorMessage;
+            this.alertService.error('Erreur', errorMessage);
+            handled = HttpErrorInterceptor.handleServerSideError(returnedError);
+          }
+
+          console.error(errorMessage);
+
+          if (!handled) {
+            if (errorMessage) {
+              return throwError(errorMessage);
+            } else {
+              return throwError('Une erreur inattendue est survenue');
+            }
+          } else {
+            return of(returnedError);
+          }
+
+        })
+      );
+  }
+}

--- a/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.ts
+++ b/frontend-implicaction/src/app/core/interceptors/http-error.interceptor.ts
@@ -14,6 +14,7 @@ export class HttpErrorInterceptor implements HttpInterceptor {
   private static handleServerSideError(error: HttpErrorResponse): boolean {
     let handled = false;
 
+    // on ignore les erreurs 401 et 403 qui sont gérées par le jwt-interceptor
     switch (error.status) {
       case 401:
         handled = true;

--- a/frontend-implicaction/src/app/shared/components/alert/alert.component.html
+++ b/frontend-implicaction/src/app/shared/components/alert/alert.component.html
@@ -1,0 +1,8 @@
+<div
+  *ngIf="alert"
+  class="alert alert-{{alert.type}} mt-4"
+  role="alert"
+>
+  <h4 class="alert-heading mb-4">{{alert.title}}</h4>
+  <p>{{alert.message}}</p>
+</div>

--- a/frontend-implicaction/src/app/shared/components/alert/alert.component.scss
+++ b/frontend-implicaction/src/app/shared/components/alert/alert.component.scss
@@ -1,0 +1,3 @@
+.alert-heading {
+  font-weight: bold;
+}

--- a/frontend-implicaction/src/app/shared/components/alert/alert.component.spec.ts
+++ b/frontend-implicaction/src/app/shared/components/alert/alert.component.spec.ts
@@ -1,0 +1,25 @@
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {AlertComponent} from './alert.component';
+
+describe('AlertComponent', () => {
+  let component: AlertComponent;
+  let fixture: ComponentFixture<AlertComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [AlertComponent]
+    })
+      .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend-implicaction/src/app/shared/components/alert/alert.component.ts
+++ b/frontend-implicaction/src/app/shared/components/alert/alert.component.ts
@@ -1,0 +1,48 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {Alert} from '../../models/alert';
+import {Subscription} from 'rxjs';
+import {NavigationStart, Router} from '@angular/router';
+import {AlertService} from '../../services/alert.service';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.scss']
+})
+export class AlertComponent implements OnInit, OnDestroy {
+
+  alert: Alert = undefined;
+  alertSubscription: Subscription;
+  routeSubscription: Subscription;
+
+  constructor(
+    private router: Router,
+    private alertService: AlertService
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.alertSubscription = this.alertService
+      .onAlert()
+      .subscribe(alert => {
+        if (!alert?.message) {
+          return;
+        }
+        this.alert = alert;
+      });
+
+    this.routeSubscription = this.router
+      .events
+      .subscribe(event => {
+        if (event instanceof NavigationStart) {
+          this.alertService.clear();
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.alertSubscription?.unsubscribe();
+    this.routeSubscription?.unsubscribe();
+  }
+
+}

--- a/frontend-implicaction/src/app/shared/models/alert.ts
+++ b/frontend-implicaction/src/app/shared/models/alert.ts
@@ -1,0 +1,9 @@
+export enum AlertType {
+  SUCCESS = 'success', DANGER = 'danger'
+}
+
+export interface Alert {
+  title?: string;
+  message?: string;
+  type?: AlertType;
+}

--- a/frontend-implicaction/src/app/shared/services/alert.service.spec.ts
+++ b/frontend-implicaction/src/app/shared/services/alert.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from '@angular/core/testing';
+
+import {AlertService} from './alert.service';
+
+describe('AlertService', () => {
+  let service: AlertService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AlertService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend-implicaction/src/app/shared/services/alert.service.ts
+++ b/frontend-implicaction/src/app/shared/services/alert.service.ts
@@ -1,0 +1,34 @@
+import {Injectable} from '@angular/core';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {Alert, AlertType} from '../models/alert';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AlertService {
+
+  private subject = new BehaviorSubject<Alert>(null);
+
+  constructor() {
+  }
+
+  onAlert(): Observable<Alert> {
+    return this.subject.asObservable();
+  }
+
+  success(title: string, message: string): void {
+    this.alert({title, message, type: AlertType.SUCCESS});
+  }
+
+  error(title: string, message: string): void {
+    this.alert({title, message, type: AlertType.DANGER});
+  }
+
+  clear(): void {
+    this.subject.next(null);
+  }
+
+  private alert(alert: Alert): void {
+    this.subject.next(alert);
+  }
+}

--- a/frontend-implicaction/src/app/shared/shared.module.ts
+++ b/frontend-implicaction/src/app/shared/shared.module.ts
@@ -5,16 +5,19 @@ import {RouterModule} from '@angular/router';
 import {BadgeModule} from 'primeng/badge';
 import {IconsModule} from '../icons/icons.module';
 import {LoadingComponent} from './components/loading/loading.component';
+import {AlertComponent} from './components/alert/alert.component';
 
 
 @NgModule({
   declarations: [
     HeaderComponent,
     LoadingComponent,
+    AlertComponent
   ],
   exports: [
     HeaderComponent,
     LoadingComponent,
+    AlertComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
# Front

Un composant alert a été mis en place pour l'affichage des alertes (error ou success). Pour afficher une alert il suffit de reproduire le code suivant :

```html
<app-alert></app-alert>
```

```typescript
this.alertService
    .success(
         'Félicitation',
         'Votre inscription a bien été enregistrée. Elle doit maintenant être validée par un administrateur.'
    );
```
le résultat sera le suivant :
![Capture d’écran 2021-09-25 à 15 16 55](https://user-images.githubusercontent.com/4210719/134772981-fb3f3bd9-2077-4daa-842a-6097cb885480.png)

De plus, un interceptor a été mis en place dans le but de recupérer les erreurs http renvoyées par l'api et de récupérer leurs messages pour les afficher. Ca permet d'afficher le bon message en cas de problème d'identification par exemple : 


![Capture d’écran 2021-09-25 à 15 29 46](https://user-images.githubusercontent.com/4210719/134773310-8e81d590-13f8-4c63-ab69-2de002a432df.png)

# Back

On dispose d'un ExceptionHandler ([GlobalExceptionHandler.java](https://github.com/dyno-nuggets/refonte-implicaction/blob/develop/backend-implicaction/src/main/java/com/dynonuggets/refonteimplicaction/handler/GlobalExceptionHandler.java)) qui intercepte les exceptions paramétrées et renvoie une réponse correspondant à cette exception avec le code http qui convient ex: UserNotFoundException => 404