### PR TITLE
RI-111: ajoute le composant de filtrage aux tableaux d'admin des offres d'emploi

### DIFF
--- a/frontend-implicaction/src/app/admin/admin-routing.module.ts
+++ b/frontend-implicaction/src/app/admin/admin-routing.module.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {AdminComponent} from './admin.component';
+import {JobFilterComponent} from '../shared/components/job-filter/job-filter.component';
 
 
 const routes: Routes = [
@@ -30,7 +31,13 @@ const routes: Routes = [
       {
         path: '',
         loadChildren: () => import('./jobs/admin-jobs.module').then(m => m.AdminJobsModule),
-        outlet: 'admin-content'
+        outlet: 'admin-content',
+
+      },
+      {
+        path: '',
+        component: JobFilterComponent,
+        outlet: 'admin-filter'
       }
     ]
   },

--- a/frontend-implicaction/src/app/admin/admin.component.html
+++ b/frontend-implicaction/src/app/admin/admin.component.html
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-md-3">
       <app-admin-menu></app-admin-menu>
+      <router-outlet name="admin-filter"></router-outlet>
     </div>
     <div class="col-md-9">
       <router-outlet name="admin-content"></router-outlet>

--- a/frontend-implicaction/src/app/admin/jobs/components/jobs-table/jobs-table.component.ts
+++ b/frontend-implicaction/src/app/admin/jobs/components/jobs-table/jobs-table.component.ts
@@ -10,6 +10,9 @@ import {JobCriteriaFilter} from '../../../../job/models/job-criteria-filter';
 import {JobPosting} from '../../../../shared/models/job-posting';
 import {JobPostingFormComponent} from '../job-posting-form/job-posting-form.component';
 import {SidebarService} from '../../../../shared/services/sidebar.service';
+import {SortDirectionEnum} from '../../../../shared/enums/sort-direction.enum';
+import {JobFilterContextService} from '../../../../job/services/job-filter-context.service';
+import {ActivatedRoute} from '@angular/router';
 
 @Component({
   selector: 'app-jobs-table',
@@ -25,13 +28,98 @@ export class JobsTableComponent {
   pageable: Pageable = Constants.PAGEABLE_DEFAULT;
   orderByEnums = JobSortEnum.all();
   selectedOrder = JobSortEnum.DATE_DESC;
-  jobCriteria: JobCriteriaFilter;
+  criteria: JobCriteriaFilter;
+  selectedOrderCode: string;
+  sortDirection = SortDirectionEnum;
 
   constructor(
     private jobService: JobService,
     private toastService: ToasterService,
-    private sidebarService: SidebarService
+    private sidebarService: SidebarService,
+    private filterService: JobFilterContextService,
+    private route: ActivatedRoute
   ) {
+  }
+
+  ngOnInit(): void {
+    this.pageable.sortOrder = JobSortEnum.DATE_DESC.sortDirection;
+    this.pageable.sortBy = JobSortEnum.DATE_DESC.sortBy;
+    this.selectedOrderCode = JobSortEnum.DATE_DESC.code;
+
+    this.filterService
+      .observeFilter()
+      .subscribe(criteria => {
+        this.criteria = criteria;
+        const objectParam = this.buildQueryParams();
+        this.filterService.updateRouteQueryParams(objectParam);
+        this.paginate();
+      });
+
+    this.getFilterFromQueryParams()
+      .then(() => this.filterService.setFilter(this.criteria));
+  }
+
+  paginate({page, first, rows} = this.pageable): void {
+    this.loading = true;
+    this.pageable.page = page;
+    this.pageable.first = first;
+    this.pageable.rows = rows;
+    this.jobService
+      .getAllByCriteria(this.pageable, this.criteria)
+      .pipe(finalize(() => this.loading = false))
+      .subscribe(
+        data => {
+          this.pageable.totalPages = data.totalPages;
+          this.pageable.totalElements = data.totalElements;
+          this.pageable.content = data.content;
+        },
+        () => this.toastService.error('Oops', 'Une erreur est survenue lors de la récupération de la liste des offres')
+      );
+  }
+
+  onSortChange({value}): void {
+    const selectedOrderField = JobSortEnum.from(value);
+    this.pageable.sortBy = selectedOrderField.sortBy;
+    this.pageable.sortOrder = selectedOrderField.sortDirection;
+    this.filterService.setFilter(this.criteria); // on relance la recherche en updatant le filtre
+  }
+
+  onSearchChange(): void {
+    this.filterService.setFilter(this.criteria);
+  }
+
+  private async getFilterFromQueryParams(): Promise<void> {
+    // TODO: voir si y'a un moyen plus élégant avec typeof
+    const filterKeys = ['search', 'contractType'];
+    const pageableKeys = ['rows', 'page', 'sortOrder', 'sortBy'];
+    return new Promise(resolve => {
+      this.route
+        .queryParams
+        .subscribe(params => {
+          Object.entries(params)
+            .forEach(([key, value]) => {
+              if (filterKeys.includes(key)) {
+                this.criteria[key] = value;
+              } else if (pageableKeys.includes(key)) {
+                this.pageable[key] = value;
+              }
+            });
+          return resolve();
+        });
+    });
+  }
+
+  /**
+   * @return any les filtres de recherche auxquels sont ajoutés les filtres de pagination
+   */
+  private buildQueryParams(): any {
+    return {
+      ...this.criteria,
+      size: this.pageable.rows,
+      page: this.pageable.page,
+      sortBy: this.pageable.sortBy,
+      sortOrder: this.pageable.sortOrder
+    };
   }
 
   loadJobs(event: LazyLoadEvent): void {
@@ -39,7 +127,7 @@ export class JobsTableComponent {
     const page = event.first / event.rows;
 
     this.jobService
-      .getAllByCriteria({page, rows: event.rows}, this.jobCriteria)
+      .getAllByCriteria({page, rows: event.rows}, this.criteria)
       .pipe(
         take(1),
         finalize(() => this.loading = false)

--- a/frontend-implicaction/src/app/admin/jobs/components/jobs-table/jobs-table.component.ts
+++ b/frontend-implicaction/src/app/admin/jobs/components/jobs-table/jobs-table.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {Pageable} from '../../../../shared/models/pageable';
 import {Constants} from '../../../../config/constants';
 import {ToasterService} from '../../../../core/services/toaster.service';
@@ -19,7 +19,7 @@ import {ActivatedRoute} from '@angular/router';
   templateUrl: './jobs-table.component.html',
   styleUrls: ['./jobs-table.component.scss']
 })
-export class JobsTableComponent {
+export class JobsTableComponent implements OnInit {
 
   readonly ROWS_PER_PAGE_OPTIONS = Constants.ROWS_PER_PAGE_OPTIONS;
   loading = true; // indique si les données sont en chargement

--- a/frontend-implicaction/src/app/admin/shared/components/admin-menu/admin-menu.component.html
+++ b/frontend-implicaction/src/app/admin/shared/components/admin-menu/admin-menu.component.html
@@ -3,7 +3,6 @@
 
     <ng-container *ngFor="let menuItem of allowedMenuItems">
       <a
-        [routerLinkActiveOptions]="{exact: true}"
         [routerLink]="menuItem.link"
         class="list-group-item d-flex justify-content-between"
         routerLinkActive="active"


### PR DESCRIPTION
![111](https://user-images.githubusercontent.com/85649177/140411148-679b0a1f-d1ad-42ec-ac5b-7a5a5d3cc6f0.gif)

Le hic dans ce ticket : 
Quand on click sur les offres, l'url est http://localhost:4200/admin/jobs?size=10&sortBy=createdAt&sortOrder=DESC, quand je sélectionne à nouveau les offres l'url est http://localhost:4200/admin/jobs.
Ce qui fait que le menu n'apparait pas comme actif.

A voir si ça va être traitée dans cette PR ou une autre 

![111-bug](https://user-images.githubusercontent.com/85649177/140411560-2425c932-d70d-4630-bc13-4634e7bdf4c3.gif)

