### PR TITLE
fix: corrige une erreur de refresh token

### DIFF
--- a/frontend-implicaction/src/app/core/guards/auth.guard.service.ts
+++ b/frontend-implicaction/src/app/core/guards/auth.guard.service.ts
@@ -15,10 +15,7 @@ export class AuthGuard implements CanActivate {
   }
 
   private static getRoutePermissions(route: ActivatedRouteSnapshot): RoleEnumCode[] {
-    if (route.data && route.data.allowedRoles) {
-      return route.data.allowedRoles;
-    }
-    return null;
+    return route.data?.allowedRoles;
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {

--- a/frontend-implicaction/src/app/core/services/auth.service.ts
+++ b/frontend-implicaction/src/app/core/services/auth.service.ts
@@ -44,8 +44,8 @@ export class AuthService {
     return this.http.post<LoginResponse>(this.apiEndpointsService.getLoginEndpoint(), loginRequestPayload)
       .pipe(
         map(loginResponse => {
-          const principal = this.decodeToken(loginResponse.authenticationToken);
           this.storageService.storeLoginResponse(loginResponse);
+          const principal = this.decodeToken(loginResponse.authenticationToken);
           this.storeAndEmitPrincipal(principal);
           return principal;
         }),
@@ -91,7 +91,11 @@ export class AuthService {
       this.apiEndpointsService.getJwtRefreshTokenEndpoint(),
       refreshTokenPayload
     )
-      .pipe(tap(response => this.storageService.storeLoginResponse(response)));
+      .pipe(tap(loginResponse => {
+        this.storageService.storeLoginResponse(loginResponse);
+        const principal = this.decodeToken(loginResponse.authenticationToken);
+        this.storeAndEmitPrincipal(principal);
+      }));
   }
 
   getRefreshToken(): string {


### PR DESCRIPTION
Les rôles de l'utilisateur n'étaient pas remontés au front lors d'un refresh token ce qui empéchait de franchir le auth.guard